### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/3a-PythonVariables/1.md
+++ b/3a-PythonVariables/1.md
@@ -42,7 +42,7 @@ Here is the reference material.
 
 * [Dive into Python] (http://www.diveintopython.net/toc/index.html)
 * [Software Carpentry's Python Lectures] (http://software-carpentry.org/4_0/python/)
-* [IPython: A System for Interactive Scientific Computing] (http://dx.doi.org/10.1109/MCSE.2007.53)
+* [IPython: A System for Interactive Scientific Computing] (https://doi.org/10.1109/MCSE.2007.53)
 * [How to Think Like a Computer Scientist] (http://www.greenteapress.com/thinkpython/thinkpython.html)
 
 Once we briefly deal with ipython, I'll cover python in the following order:

--- a/3a-PythonVariables/Readme.md
+++ b/3a-PythonVariables/Readme.md
@@ -42,7 +42,7 @@ Here is the reference material.
 
 * [Dive into Python] (http://www.diveintopython.net/toc/index.html)
 * [Software Carpentry's Python Lectures] (http://software-carpentry.org/4_0/python/)
-* [IPython: A System for Interactive Scientific Computing] (http://dx.doi.org/10.1109/MCSE.2007.53)
+* [IPython: A System for Interactive Scientific Computing] (https://doi.org/10.1109/MCSE.2007.53)
 * [How to Think Like a Computer Scientist] (http://www.greenteapress.com/thinkpython/thinkpython.html)
 
 Once we briefly deal with ipython, I'll cover python in the following order:


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly.

Cheers!